### PR TITLE
Atualizando para 2025

### DIFF
--- a/.github/ISSUE_TEMPLATE/01 - create-in-person-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/01 - create-in-person-meeting.yml
@@ -18,7 +18,7 @@ body:
     attributes:
       label: Nome do(a) Evento/Agenda
       description: Qual o nome do(a) evento/agenda?
-      placeholder: "ex: TDC 2024"
+      placeholder: "ex: TDC 2025"
     validations:
       required: true
 
@@ -96,7 +96,6 @@ body:
       multiple: false
       default: 0
       options:
-        - "2024"
         - "2025"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/02 - create-hybrid-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/02 - create-hybrid-meeting.yml
@@ -18,7 +18,7 @@ body:
     attributes:
       label: Nome do(a) Evento/Agenda
       description: Qual o nome do(a) evento/agenda?
-      placeholder: "ex: TDC 2024"
+      placeholder: "ex: TDC 2025"
     validations:
       required: true
 
@@ -96,7 +96,6 @@ body:
       multiple: false
       default: 0
       options:
-        - "2024"
         - "2025"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/03 - create-online-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/03 - create-online-meeting.yml
@@ -18,7 +18,7 @@ body:
     attributes:
       label: Nome do(a) Evento/Agenda
       description: Qual o nome do(a) evento/agenda?
-      placeholder: "ex: TDC 2024"
+      placeholder: "ex: TDC 2025"
     validations:
       required: true
 
@@ -44,7 +44,6 @@ body:
       multiple: false
       default: 0
       options:
-        - "2024"
         - "2025"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/04 - delete-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/04 - delete-meeting.yml
@@ -20,7 +20,7 @@ body:
     attributes:
       label: Nome do(a) Evento/Agenda
       description: Qual o nome do(a) evento/agenda?
-      placeholder: "ex: TDC 2024"
+      placeholder: "ex: TDC 2025"
     validations:
       required: true
 
@@ -32,7 +32,6 @@ body:
       multiple: false
       default: 0
       options:
-        - "2024"
         - "2025"
     validations:
       required: true


### PR DESCRIPTION
Remove opção de 2024 ao criar eventos presenciais, online e hibridos e atualiza exemplo de "TDC 2024" para "TDC 2025"